### PR TITLE
fix(workflows): yarnlock changes

### DIFF
--- a/.github/workflows/apps-yarnlock.yaml
+++ b/.github/workflows/apps-yarnlock.yaml
@@ -1,9 +1,13 @@
 name: Application GHA - Yarn Lock Changes
 run-name: "YARN.LOCK CHANGES"
-on: [push, workflow_dispatch]
+on: [push]
 jobs:
   yarn_lock_changes:
     runs-on: ubuntu-latest
+    permissions:
+        pull-requests: write
+        id-token: write
+        contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Ref: #346
Under the hood the IDDQD mode has been enabled for github token/actions