### PR TITLE
fix(docs): typo in env vars

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -4,7 +4,7 @@
 ### `wlType`
 This environment variable is used to determine which environment the platform is running in.
 
-Possbile values:
+Possible values:
 * `LOCAL`
 * `DEV`
 * `TEST`


### PR DESCRIPTION
Ref: #547