### PR TITLE
feat(client): `onAfterRequest` call and check for response code

### DIFF
--- a/applications/packages/core/core.http/package.json
+++ b/applications/packages/core/core.http/package.json
@@ -10,7 +10,7 @@
             "types": "./dist/index.d.ts"
         }
     },
-    "version": "4.0.0",
+    "version": "4.1.0",
     "license": "LGPL-3.0-only",
     "scripts": {
         "lint": "eslint .",

--- a/applications/packages/core/core.http/src/client/core-http.client.ts
+++ b/applications/packages/core/core.http/src/client/core-http.client.ts
@@ -20,10 +20,10 @@ export class CoreHttpClient extends HttpClient {
         return true;
     }
 
-    protected onAfterCall(
+    protected onAfterCall<T>(
         _url: string,
         _responseCode: HttpCode,
-        _responseText: string
+        _responseText: T
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     ): void {
     }


### PR DESCRIPTION
Ref: #702